### PR TITLE
EMISWEB-104 feat(menus): hide instance uninstalled modules from side and dashboard menus

### DIFF
--- a/src/app/AppWrapper.tsx
+++ b/src/app/AppWrapper.tsx
@@ -2,11 +2,13 @@ import React from 'react'
 import { CenteredContent, CircularLoader } from "@dhis2/ui";
 import { useDataStore } from '../hooks/appwarapper/useDataStore';
 import { AppConfigurationsProps } from '../types/app/AppConfigurationsProps';
+import { useGetInstanceApps } from '../hooks/appwarapper/useGetInstanceApps';
 
 export default function AppWrapper(props: AppConfigurationsProps) {
     const { error, loading } = useDataStore()
+    const { error: errorApps, loading: loadingApps } = useGetInstanceApps();
 
-    if (loading) {
+    if (loading || loadingApps) {
         return (
             <CenteredContent>
                 <CircularLoader />
@@ -14,7 +16,7 @@ export default function AppWrapper(props: AppConfigurationsProps) {
         )
     }
 
-    if (error != null) {
+    if (error != null || errorApps) {
         return (
             <CenteredContent>
                 Something went wrong wen loading the app, please check if you app is already configured

--- a/src/components/layout/sidebar/SideBar.tsx
+++ b/src/components/layout/sidebar/SideBar.tsx
@@ -2,19 +2,18 @@ import React, { useState } from 'react'
 import style from "./SideBar.module.css"
 import SideBarItem from './components/SideBarItem'
 import SibeBarCollapseButton from './components/SibeBarCollapseButton';
-import { menuData } from '../../../utils';
 import { MenuDataProps } from '../../../types/menu/MenuTypes';
-import { getDataStoreKeys } from '../../../utils/common/dataStore/getDataStoreKeys';
+import { useMenuData } from '../../../hooks/menu/useMenuData';
 
 export default function SideBar(): React.ReactElement {
+    const { menuData } = useMenuData()
     const [collapsed, setCollapsed] = useState<boolean>(false);
-    const { currentAcademicYear } = getDataStoreKeys()
 
     return (
         <aside className={collapsed ? style.sideBarContainerCollapsed : style.sideBarContainer}>
             <div className={style.sideBarMenu}>
                 {
-                    menuData(currentAcademicYear).map((element:MenuDataProps, index) => (
+                    menuData?.filter((element) => element.displayInMenu)?.map((element: MenuDataProps, index) => (
                         <SideBarItem key={index} title={element.title} subItem={element.subItem} />
                     ))
                 }

--- a/src/hooks/appwarapper/useGetInstanceApps.ts
+++ b/src/hooks/appwarapper/useGetInstanceApps.ts
@@ -1,0 +1,39 @@
+import { useSetRecoilState } from 'recoil'
+import { useState, useEffect } from 'react'
+import { useDataEngine } from "@dhis2/app-runtime"
+import { InstanceAppState } from '../../schema/instanceAppsSchema'
+
+const ModulesQuery = {
+    results: {
+        resource: "apps"
+    }
+}
+
+
+const useGetInstanceApps = () => {
+    const engine = useDataEngine()
+    const [error, setError] = useState<boolean>(false)
+    const setData = useSetRecoilState(InstanceAppState)
+    const [loading, setLoading] = useState<boolean>(false)
+
+    const getInstanceApps = async () => {
+        await engine.query(ModulesQuery, {
+            onComplete: (response) => {
+                setData(response?.results)
+                setLoading(false)
+            },
+            onError: () => {
+                setError(true)
+                setLoading(false)
+            }
+        })
+    }
+
+    useEffect(() => {
+        getInstanceApps()
+    }, [])
+
+    return { loading, error }
+}
+
+export { useGetInstanceApps }

--- a/src/hooks/menu/useMenuData.ts
+++ b/src/hooks/menu/useMenuData.ts
@@ -1,0 +1,16 @@
+import { menuData } from "../../utils";
+import { useRecoilValue } from "recoil";
+import { formatMenuData } from "../../utils/common/formatMenuData";
+import { InstanceAppState } from "../../schema/instanceAppsSchema";
+import { getDataStoreKeys } from "../../utils/common/dataStore/getDataStoreKeys"
+
+const useMenuData = () => {
+    const { currentAcademicYear } = getDataStoreKeys();
+    const instanceApps = useRecoilValue(InstanceAppState)
+
+    return {
+        menuData: formatMenuData(menuData(currentAcademicYear), instanceApps)
+    }
+}
+
+export { useMenuData }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,20 +1,21 @@
 import React from "react";
 import style from "./Home.module.css";
 import { DashboardCard, Title, WithPadding } from "../../components";
-import {menuData} from "../../utils/index"
+import { menuData } from "../../utils/index"
 import { MenuDataItemProps, MenuDataProps } from "../../types/menu/MenuTypes";
 import { getDataStoreKeys } from "../../utils/common/dataStore/getDataStoreKeys";
+import { useMenuData } from "../../hooks/menu/useMenuData";
 
 function Home(): React.ReactElement {
-    const { currentAcademicYear } = getDataStoreKeys()
-    
-    return (
+  const { menuData } = useMenuData()
+
+  return (
     <WithPadding padding="10px 30px">
-      {menuData(currentAcademicYear).filter(item => item.displayInDashboard === true).map((section:MenuDataProps, y) => (
+      {menuData?.filter(item => item.displayInDashboard && item.displayInMenu).map((section: MenuDataProps, y) => (
         <div key={y} className={style.section}>
-          <Title label={section.title}/>
+          <Title label={section.title} />
           <div className={style.containerCards}>
-            {section.subItem.map((data: MenuDataItemProps, i: number) => (
+            {section.subItem?.filter((data: MenuDataItemProps) => data.displayInMenu).map((data: MenuDataItemProps, i: number) => (
               <div key={i}>
                 <DashboardCard
                   program={data.program}

--- a/src/schema/instanceAppsSchema.ts
+++ b/src/schema/instanceAppsSchema.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil"
+import { InstanceAppType } from "../types/instance/InstanceAppsTypes"
+
+export const InstanceAppState = atom<InstanceAppType[]>({
+    key: "InstanceApp-get-state",
+    default: []
+})

--- a/src/types/instance/InstanceAppsTypes.ts
+++ b/src/types/instance/InstanceAppsTypes.ts
@@ -1,0 +1,14 @@
+interface InstanceAppType {
+    appType: string 
+    baseUrl: string
+    description: string
+    folderName: string
+    key: string
+    launchUrl: string
+    launch_path: string
+    name: string
+    short_name: string
+    version: string
+}
+
+export type { InstanceAppType }

--- a/src/types/menu/MenuTypes.ts
+++ b/src/types/menu/MenuTypes.ts
@@ -1,10 +1,12 @@
 interface MenuDataProps {
     title: string
+    displayInMenu?: boolean
     displayInDashboard?: boolean
     subItem: MenuDataItemProps[]
 }
 
 interface MenuDataItemProps {
+    displayInMenu?: boolean
     dashBoardIcon: string
     sidebarIcon:string
     title: string

--- a/src/utils/common/formatMenuData.ts
+++ b/src/utils/common/formatMenuData.ts
@@ -1,0 +1,17 @@
+import { InstanceAppType } from "../../types/instance/InstanceAppsTypes";
+import { MenuDataItemProps, MenuDataProps } from "../../types/menu/MenuTypes";
+
+export function formatMenuData(menuData: MenuDataProps[], appsList: InstanceAppType[]): MenuDataProps[] {
+    menuData?.filter((menuItem: MenuDataProps) => menuItem.displayInDashboard)?.map((menuItem: MenuDataProps) => {
+        menuItem?.subItem?.map((menuSubItem: MenuDataItemProps) => {
+            menuSubItem.displayInMenu = Boolean(appsList?.find((app) => app.key === menuSubItem.appName))
+        })
+    })
+
+
+    menuData?.filter((menuItem: MenuDataProps) => menuItem.displayInDashboard)?.map((menuItem: MenuDataProps) => {
+        menuItem.displayInMenu = !Boolean(menuItem?.subItem?.every((menuSubItem: MenuDataItemProps) => !menuSubItem.displayInMenu))
+    })
+
+    return menuData
+}

--- a/src/utils/constants/menuData.ts
+++ b/src/utils/constants/menuData.ts
@@ -16,6 +16,7 @@ function menuData(currentAcademicYear: string): MenuDataProps[] {
     return [
         {
             title: "Navigation",
+            displayInMenu: true,
             displayInDashboard: false,
             subItem: [
                 {


### PR DESCRIPTION
Changes: 
* hook to get instance apps added; 
* function to format menuData based on existence of correspondant modules on instance; 
* new variable added to menuProps to help hidding unwanted modules